### PR TITLE
AIQ-6426 Fix the errors of empty text boxes

### DIFF
--- a/lib/xmlnode.js
+++ b/lib/xmlnode.js
@@ -141,7 +141,7 @@ class Xml {
     }
 
     text() {
-        return this.xml[Xml.CHILD_KEY][0].text;
+        return this.xml[Xml.CHILD_KEY]?.[0].text;
     }
 
     setText(text) {


### PR DESCRIPTION
Fixes for:

- https://anthemiq.atlassian.net/browse/AIQ-6456
- https://anthemiq.atlassian.net/browse/AIQ-6457

Basically, this was causing some errors when the text boxes were empty. Now it is going to mimic the behavior of:

https://github.com/anthemiq/node-pptx/blob/master/lib/text-box.js#L163